### PR TITLE
Update PAN-OS versions to 11.2.2

### DIFF
--- a/products/pan-os.md
+++ b/products/pan-os.md
@@ -28,9 +28,9 @@ releases:
 -   releaseCycle: "11.2"
     releaseDate: 2024-05-02
     eol: 2027-05-02
-    latest: "11.2.1"
-    latestReleaseDate: 2024-07-08
-    link: https://docs.paloaltonetworks.com/pan-os/11-2/pan-os-release-notes/pan-os-11-2-1-known-and-addressed-issues/pan-os-11-2-1-addressed-issues
+    latest: "11.2.2"
+    latestReleaseDate: 2024-07-30
+    link: https://docs.paloaltonetworks.com/pan-os/11-2/pan-os-release-notes/pan-os-11-2-2-known-and-addressed-issues/pan-os-11-2-2-addressed-issues
 
 -   releaseCycle: "11.1"
     releaseDate: 2023-11-03
@@ -63,9 +63,9 @@ releases:
 -   releaseCycle: "10.0"
     releaseDate: 2020-07-16
     eol: 2022-07-16
-    latest: "10.0.12-h5"
-    latestReleaseDate: 2023-12-18
-    link: https://docs.paloaltonetworks.com/pan-os/10-0/pan-os-release-notes/pan-os-10-0-addressed-issues/pan-os-10-0-12-h5-addressed-issues
+    latest: "10.0.12-h6"
+    latestReleaseDate: 2024-05-29
+    link: https://docs.paloaltonetworks.com/pan-os/10-0/pan-os-release-notes/pan-os-10-0-addressed-issues/pan-os-10-0-12-h6-addressed-issues
 
 -   releaseCycle: "9.1"
     releaseDate: 2019-12-13


### PR DESCRIPTION
[panos] This PR updates the PAN-OS versions and their release dates.
 Pan-OS Version:11.2.2 
 Released: 2024/07/30 12:37:11